### PR TITLE
Improve AR table replace assertion

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -880,10 +880,11 @@ ar_general_foreach(VALUE hash, st_foreach_check_callback_func *func, st_update_c
                 return 0;
               case ST_REPLACE:
                 if (replace) {
+                    ar_table_pair *orig_pair = pair;
                     (*replace)(&key, &val, arg, TRUE);
 
-                    // TODO: pair should be same as pair before.
                     pair = RHASH_AR_TABLE_REF(hash, i);
+                    HASH_ASSERT(orig_pair == pair);
                     pair->key = (VALUE)key;
                     pair->val = (VALUE)val;
                 }


### PR DESCRIPTION
## Summary
- improve hash internal iteration by verifying that AR table entries remain stable after `st_update_callback_func` replaces a key-value pair.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c7d18098c83279fc24dc23fc6d756