### PR TITLE
Fix loop counter type mismatch

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2484,7 +2484,7 @@ array_to_idlist(VALUE arr)
     RUBY_ASSERT(RB_TYPE_P(arr, T_ARRAY));
     long size = RARRAY_LEN(arr);
     ID *ids = (ID *)ALLOC_N(ID, size + 1);
-    for (int i = 0; i < size; i++) {
+    for (long i = 0; i < size; i++) {
         VALUE sym = RARRAY_AREF(arr, i);
         ids[i] = SYM2ID(sym);
     }


### PR DESCRIPTION
## Summary
- prevent potential overflow in `array_to_idlist`

## Testing
- `autoconf --version` *(fails: command not found)*
- `make check` *(fails: no rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_685c7d18098c83279fc24dc23fc6d756