### PR TITLE
Fix race condition in signal handler query

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -664,6 +664,8 @@ ruby_nativethread_signal(int signum, sighandler_t handler)
 #endif
 #endif
 
+static rb_nativethread_lock_t sig_check_lock;
+
 static int
 signal_ignored(int sig)
 {
@@ -674,7 +676,6 @@ signal_ignored(int sig)
     if (sigaction(sig, NULL, &old) < 0) return FALSE;
     func = old.sa_handler;
 #else
-    static rb_nativethread_lock_t sig_check_lock = RB_NATIVETHREAD_LOCK_INIT;
     sighandler_t old;
     rb_native_mutex_lock(&sig_check_lock);
     old = signal(sig, SIG_DFL);
@@ -1508,6 +1509,7 @@ Init_signal(void)
     rb_define_method(rb_eSignal, "signo", esignal_signo, 0);
     rb_alias(rb_eSignal, rb_intern_const("signm"), rb_intern_const("message"));
     rb_define_method(rb_eInterrupt, "initialize", interrupt_init, -1);
+    rb_native_mutex_initialize(&sig_check_lock);
 
     // It should be ready to call rb_signal_exec()
     VM_ASSERT(GET_THREAD()->pending_interrupt_queue);
@@ -1560,3 +1562,13 @@ Init_signal(void)
 
     rb_enable_interrupt();
 }
+
+#if defined(HAVE_WORKING_FORK)
+void
+rb_signal_atfork(void)
+{
+    rb_native_mutex_initialize(&sig_check_lock);
+}
+#else
+void rb_signal_atfork(void) {}
+#endif

--- a/thread.c
+++ b/thread.c
@@ -4933,6 +4933,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     thread_sched_atfork(TH_SCHED(th));
     ubf_list_atfork();
+    rb_signal_atfork();
 
     // OK. Only this thread accesses:
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
@@ -4976,6 +4977,7 @@ terminate_atfork_i(rb_thread_t *th, const rb_thread_t *current_th)
 }
 
 void rb_fiber_atfork(rb_thread_t *);
+void rb_signal_atfork(void);
 void
 rb_thread_atfork(void)
 {


### PR DESCRIPTION
## Summary
- protect non-POSIX signal handler query with a mutex to avoid races
- initialize the mutex in `Init_signal`
- reset the mutex after `fork` to avoid deadlocks

## Testing
- `make -f common.mk btest` *(fails: No rule to make target '-btest', needed by 'btest'.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_685cd0b6f20483279ec6ed909fe00ff8