### PR TITLE
Refactor octal and hex scanners

### DIFF
--- a/util.c
+++ b/util.c
@@ -42,40 +42,19 @@ const char ruby_hexdigits[] = "0123456789abcdef0123456789ABCDEF";
 unsigned long
 ruby_scan_oct(const char *start, size_t len, size_t *retlen)
 {
-    register const char *s = start;
-    register unsigned long retval = 0;
-    size_t i;
-
-    for (i = 0; i < len; i++) {
-        if ((s[0] < '0') || ('7' < s[0])) {
-            break;
-        }
-        retval <<= 3;
-        retval |= *s++ - '0';
-    }
-    *retlen = (size_t)(s - start);
-    return retval;
+    int overflow;
+    unsigned long val = ruby_scan_digits(start, (ssize_t)len, 8, retlen, &overflow);
+    (void)overflow;
+    return val;
 }
 
 unsigned long
 ruby_scan_hex(const char *start, size_t len, size_t *retlen)
 {
-    register const char *s = start;
-    register unsigned long retval = 0;
-    signed char d;
-    size_t i = 0;
-
-    for (i = 0; i < len; i++) {
-        d = ruby_digit36_to_number_table[(unsigned char)*s];
-        if (d < 0 || 15 < d) {
-            break;
-        }
-        retval <<= 4;
-        retval |= d;
-        s++;
-    }
-    *retlen = (size_t)(s - start);
-    return retval;
+    int overflow;
+    unsigned long val = ruby_scan_digits(start, (ssize_t)len, 16, retlen, &overflow);
+    (void)overflow;
+    return val;
 }
 
 const signed char ruby_digit36_to_number_table[] = {


### PR DESCRIPTION
## Summary
- refactor `ruby_scan_oct` and `ruby_scan_hex` to delegate to `ruby_scan_digits`

## Testing
- `gcc -c util.c -o util.o` *(fails: `ruby/internal/config.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e0bcc6b7483279acbaec72ad46840