### PR TITLE
Fix FileUtils.remove_dir argument validation

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1491,7 +1491,8 @@ module FileUtils
   # Related: {methods for deleting}[rdoc-ref:FileUtils@Deleting].
   #
   def remove_dir(path, force = false)
-    remove_entry path, force   # FIXME?? check if it is a directory
+    raise Errno::ENOTDIR, path unless File.directory?(path)
+    remove_entry path, force
   end
   module_function :remove_dir
 

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1763,6 +1763,14 @@ class TestFileUtils < Test::Unit::TestCase
     assert_file_not_exist 'data/tmpdir'
   end if have_file_perm?
 
+  def test_remove_dir_with_file
+    File.write('data/tmpfile', 'dummy')
+    assert_raise(Errno::ENOTDIR) { remove_dir 'data/tmpfile' }
+    assert_file_exist 'data/tmpfile'
+  ensure
+    File.unlink('data/tmpfile') if File.exist?('data/tmpfile')
+  end
+
   def test_compare_file
     check_singleton :compare_file
     # FIXME


### PR DESCRIPTION
## Summary
- ensure FileUtils.remove_dir only accepts directories
- add unit test to cover using remove_dir on a file

## Testing
- `ruby -Ilib test/fileutils/test_fileutils.rb -n test_remove_dir_with_file --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68780c38bae083278930312885c4f212