### PR TITLE
Improve NFC normalization performance

### DIFF
--- a/lib/unicode_normalize/normalize.rb
+++ b/lib/unicode_normalize/normalize.rb
@@ -107,15 +107,33 @@ module UnicodeNormalize  # :nodoc:
     accents = ''
     nfd_string[1..-1].each_char do |accent|
       accent_class = CLASS_TABLE[accent]
-      if last_class<accent_class and composite = COMPOSITION_TABLE[start+accent]
+      if last_class < accent_class && (composite = COMPOSITION_TABLE[start + accent])
         start = composite
       else
         accents << accent
         last_class = accent_class
       end
     end
-    accents = nfc_one(accents) if accents.length>1 # TODO: change from recursion to loop
-    hangul_comp_one(start+accents)
+
+    result = start
+    until accents.empty?
+      start = accents[0]
+      last_class = CLASS_TABLE[start]-1
+      rest = ''
+      accents[1..-1].each_char do |accent|
+        accent_class = CLASS_TABLE[accent]
+        if last_class < accent_class && (composite = COMPOSITION_TABLE[start + accent])
+          start = composite
+        else
+          rest << accent
+          last_class = accent_class
+        end
+      end
+      result << start
+      accents = rest
+    end
+
+    hangul_comp_one(result)
   end
 
   def self.normalize(string, form = :nfc)


### PR DESCRIPTION
## Summary
- remove recursion from `UnicodeNormalize.nfc_one`

## Testing
- `ruby -I lib -r rbconfig -e "RbConfig::CONFIG['UNICODE_VERSION']='16.0.0'; Encoding.const_set(:UNICODE_VERSION,'16.0.0'); load 'test/test_unicode_normalize.rb'"`

------
https://chatgpt.com/codex/tasks/task_e_687aae9c237883279ec97d25acf19c1c