### PR TITLE
Improve numeric string range checks

### DIFF
--- a/string.c
+++ b/string.c
@@ -5739,14 +5739,29 @@ rb_str_include_range_p(VALUE beg, VALUE end, VALUE val, VALUE exclusive)
                 }
             }
         }
-#if 0
-        /* both edges are all digits */
-        if (ISDIGIT(*bp) && ISDIGIT(*ep) &&
+        /* both edges and value are all digits */
+        if (ISDIGIT(*bp) && ISDIGIT(*ep) && ISDIGIT(*vp) &&
             all_digits_p(bp, RSTRING_LEN(beg)) &&
-            all_digits_p(ep, RSTRING_LEN(end))) {
-            /* TODO */
+            all_digits_p(ep, RSTRING_LEN(end)) &&
+            all_digits_p(vp, RSTRING_LEN(val))) {
+            VALUE b = rb_str_to_inum(beg, 10, FALSE);
+            VALUE e = rb_str_to_inum(end, 10, FALSE);
+            VALUE v = rb_str_to_inum(val, 10, FALSE);
+
+            if (FIXNUM_P(b) && FIXNUM_P(e) && FIXNUM_P(v)) {
+                long bi = FIX2LONG(b);
+                long ei = FIX2LONG(e);
+                long vi = FIX2LONG(v);
+
+                if (bi <= vi && (RTEST(exclusive) ? vi < ei : vi <= ei))
+                    return Qtrue;
+                return Qfalse;
+            }
+            if (RTEST(rb_num_coerce_relop(b, v, idLE)) &&
+                RTEST(rb_num_coerce_relop(v, e, RTEST(exclusive) ? '<' : idLE)))
+                return Qtrue;
+            return Qfalse;
         }
-#endif
     }
     rb_str_upto_each(beg, end, RTEST(exclusive), include_range_i, (VALUE)&val);
 

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -1082,6 +1082,9 @@ class TestRange < Test::Unit::TestCase
     assert_operator(2.0..5.0, :cover?, 2.0...5.0)
     assert_operator('aa'..'zz', :cover?, 'aa'...'bb')
 
+    assert_operator('10'..'20', :cover?, '15')
+    assert_not_operator('10'...'20', :cover?, '20')
+
     assert_not_operator(2..5, :cover?, 1..5)
     assert_not_operator(2...6, :cover?, 1..5)
     assert_not_operator(2..5, :cover?, 1...6)


### PR DESCRIPTION
## Summary
- enhance `rb_str_include_range_p` to handle numeric string ranges efficiently
- extend range tests for string digits

## Testing
- `ruby test/runner.rb test/ruby/test_range.rb -n test_cover`
- `ruby test/runner.rb test/ruby/test_range.rb -n test_include`
- `ruby test/runner.rb test/ruby/test_string.rb -n test_upto_numeric`


------
https://chatgpt.com/codex/tasks/task_e_687aae9c237883279ec97d25acf19c1c